### PR TITLE
[#153211414] Fix compatibility issue with protobuf

### DIFF
--- a/meta-oe/recipes-devtools/protobuf/protobuf_2.5.0.bb
+++ b/meta-oe/recipes-devtools/protobuf/protobuf_2.5.0.bb
@@ -16,6 +16,7 @@ SRC_URI[md5sum] = "b751f772bdeb2812a2a8e7202bf1dae8"
 SRC_URI[sha256sum] = "c55aa3dc538e6fd5eaf732f4eb6b98bdcb7cedb5b91d3b5bdcf29c98c293f58e"
 
 EXTRA_OECONF += " --with-protoc=echo"
+CXXFLAGS += "-D_GLIBCXX_USE_CXX11_ABI=0"
 
 inherit autotools
 


### PR DESCRIPTION
Protobuf was not compatible with the idreader bridge because of an ABI
change in the current c++ version (C++11). To overcome this, a compiler
flag had to be set to explicitly compile for the old ABI.

Another option would have been to compile the idreader bridge with the
C++11 ABI, but this would have caused necessary changes in the classic
OS and renos java as well as the idreader bridge. Now, only one simple
change to a core recipe had to be done.